### PR TITLE
Add password support

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -266,6 +266,11 @@ impl Irc {
         self.raw(format!("PONG {}", server))
     }
 
+    /// PASS command.
+    pub fn pass(&self, password: &str) -> Result<(), Error> {
+        self.raw(format!("PASS {}", password))
+    }
+
     /// PRIVMSG command.
     pub fn privmsg(&self, target: &str, text: &str) -> Result<(), Error> {
         self.raw(format!("PRIVMSG {} :{}", target, text))
@@ -322,6 +327,9 @@ pub fn dispatch<L: Listener>(listener: L, settings: Settings) -> Result<(), Erro
     let (writer, reader) = try!(connect(settings.addr, settings.reconnection, settings.encoding));
 
     let irc = Irc::new(writer.clone());
+    if !settings.password.is_empty() {
+        try!(irc.pass(settings.password));
+    }
     try!(irc.nick(settings.nickname));
     try!(irc.user(settings.username, settings.realname));
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -24,6 +24,8 @@ pub struct Settings<'a> {
     pub auto_ping: bool,
     /// Encoding used for the connection.
     pub encoding: EncodingRef,
+    /// Server password
+    pub password: &'a str,
 }
 
 impl<'a> Settings<'a> {
@@ -52,6 +54,7 @@ impl<'a> Settings<'a> {
             auto_ident: true,
             auto_ping: true,
             encoding: UTF_8,
+            password: "",
         }
     }
 
@@ -94,6 +97,12 @@ impl<'a> Settings<'a> {
     /// Modify the encoding used for this connection.
     pub fn encoding(mut self, encoding: EncodingRef) -> Settings<'a> {
         self.encoding = encoding;
+        self
+    }
+
+    /// Modify the server password.
+    pub fn password(mut self, password: &'a str) -> Settings<'a> {
+        self.password = password;
         self
     }
 


### PR DESCRIPTION
Hello there!

I am trying to write an irc bot in rust, but the server I connect to requires a password which hiirc didn't support :crying_cat_face:

So to remedy the problem, I've added support for the [PASS](https://tools.ietf.org/html/rfc2812#section-3.1.1) command. Basically you can now do 

``` rust
Settings::new("127.0.0.1:6667", "botname")
   .password("password")
   .dispatch(FooBar).unwrap();
```
