### PR TITLE
PrefixUser passed in private_msg and private_notice methods

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -676,9 +676,9 @@ impl<'a> Dispatch<'a> {
             }
         } else {
             if !notice {
-                self.listener.private_msg(self.irc.clone(), &prefix.nickname, text);
+                self.listener.private_msg(self.irc.clone(), prefix, text);
             } else {
-                self.listener.private_notice(self.irc.clone(), &prefix.nickname, text);
+                self.listener.private_notice(self.irc.clone(), prefix, text);
             }
         }
     }

--- a/src/listener.rs
+++ b/src/listener.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use loirc::Event;
-use {Channel, ChannelUser, ChannelUserStatus, Code, Irc, Message};
+use {Channel, ChannelUser, ChannelUserStatus, Code, Irc, Message, PrefixUser};
 
 /// Implement this trait to handle events.
 pub trait Listener {
@@ -74,11 +74,11 @@ pub trait Listener {
 
     /// When a private message is received.
     #[allow(unused_variables)]
-    fn private_msg(&mut self, irc: Arc<Irc>, sender: &str, message: &str) {}
+    fn private_msg(&mut self, irc: Arc<Irc>, sender: &PrefixUser, message: &str) {}
 
     /// When a private notice is received.
     #[allow(unused_variables)]
-    fn private_notice(&mut self, irc: Arc<Irc>, sender: &str, message: &str) {}
+    fn private_notice(&mut self, irc: Arc<Irc>, sender: &PrefixUser, message: &str) {}
 
     /// Reply to a `get_topic` command and when joining a channel.
     ///


### PR DESCRIPTION
Closes #17 

I would also like to pass hostname information to the `ChannelUser` (or via some other method, but I would like to be able to read the hostname on `channel_msg` event). Do you think it's doable?